### PR TITLE
Remove CurrentActiveTab setting from FavoritePage constructor

### DIFF
--- a/FavoritePage.xaml.cs
+++ b/FavoritePage.xaml.cs
@@ -8,8 +8,8 @@ public partial class FavoritePage : ContentPage
 {
     public FavoritePage(string activeTab)
     {
-        InitializeComponent();
         TabService.CurrentActiveTab = activeTab;
+        InitializeComponent();
     }
 
     private ObservableCollection<MenuItemModel> _menuItems;


### PR DESCRIPTION
Updated the `FavoritePage` constructor in `FavoritePage.xaml.cs` to remove the line that sets the `CurrentActiveTab` property of `TabService`. The `InitializeComponent()` method call remains intact.